### PR TITLE
Meetup checks now update the target google calendar instead of always adding new events.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,14 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin.version}</version>
+        <configuration>
+          <mainClass>com.chariotsolutions.meetupnotifier.App</mainClass>
+        </configuration>
+      </plugin>
 
     </plugins>
   </build>
@@ -133,6 +141,7 @@
     <log4j.version>1.2.17</log4j.version>
     <slf4j-log4j12.version>1.7.12</slf4j-log4j12.version>
     <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
+    <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
   </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
       <artifactId>hsqldb</artifactId>
       <version>${hsqldb.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
 
 
   </dependencies>
@@ -154,6 +159,7 @@
     <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
     <spring-jdbc.version>4.1.7.RELEASE</spring-jdbc.version>
     <hsqldb.version>2.3.3</hsqldb.version>
+    <guava.version>18.0</guava.version>
   </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
       <version>${spring-context.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+      <version>${spring-jdbc.version}</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>
@@ -65,6 +70,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j-log4j12.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <version>${hsqldb.version}</version>
     </dependency>
 
 
@@ -142,6 +152,8 @@
     <slf4j-log4j12.version>1.7.12</slf4j-log4j12.version>
     <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
     <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
+    <spring-jdbc.version>4.1.7.RELEASE</spring-jdbc.version>
+    <hsqldb.version>2.3.3</hsqldb.version>
   </properties>
 
 </project>

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEvent.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEvent.java
@@ -1,10 +1,10 @@
 package com.chariotsolutions.meetupnotifier;
 
-public class EventIdRow {
+public class CalendarEvent {
   private String googleId;
   private String meetupId;
 
-  public EventIdRow(String googleId, String meetupId) {
+  public CalendarEvent(String googleId, String meetupId) {
     this.googleId = googleId;
     this.meetupId = meetupId;
   }

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEvent.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEvent.java
@@ -1,10 +1,14 @@
 package com.chariotsolutions.meetupnotifier;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class CalendarEvent {
   private String googleId;
   private String meetupId;
 
   public CalendarEvent(String googleId, String meetupId) {
+    checkArgument(googleId.length() > 0, "The google ID should not be 0 length");
+    checkArgument(meetupId.length() > 0, "The meetup ID should not be 0 length");
     this.googleId = googleId;
     this.meetupId = meetupId;
   }

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEvent.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEvent.java
@@ -1,13 +1,16 @@
 package com.chariotsolutions.meetupnotifier;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CalendarEvent {
   private String googleId;
   private String meetupId;
 
   public CalendarEvent(String googleId, String meetupId) {
+    checkNotNull(googleId);
     checkArgument(googleId.length() > 0, "The google ID should not be 0 length");
+    checkNotNull(meetupId);
     checkArgument(meetupId.length() > 0, "The meetup ID should not be 0 length");
     this.googleId = googleId;
     this.meetupId = meetupId;

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDao.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDao.java
@@ -1,0 +1,31 @@
+package com.chariotsolutions.meetupnotifier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CalendarEventDao {
+
+  @Autowired
+  JdbcTemplate template;
+
+  void insertRow(String googleId, String meetupId) {
+    template.update(
+        "INSERT INTO calendar_event VALUES (?, ?)", googleId, meetupId);
+  }
+
+  List<CalendarEvent> getRowsByMeetupId(String meetupId) {
+    return template.query(
+        "SELECT * from calendar_event where meetupID=?", eventMapper, meetupId);
+  }
+
+  RowMapper<CalendarEvent> eventMapper = (resultSet, ii) -> new CalendarEvent(
+      resultSet.getString("googleID"),
+      resultSet.getString("meetupID"));
+
+
+}

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDao.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDao.java
@@ -1,31 +1,11 @@
 package com.chariotsolutions.meetupnotifier;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
-public class CalendarEventDao {
+public interface CalendarEventDao {
 
-  @Autowired
-  private JdbcTemplate template;
+  List<CalendarEvent> findEventsByMeetupId(String meetupId);
 
-  void insertEvent(String googleId, String meetupId) {
-    template.update(
-        "INSERT INTO calendar_event VALUES (?, ?)", googleId, meetupId);
-  }
-
-  List<CalendarEvent> findEventsByMeetupId(String meetupId) {
-    return template.query(
-        "SELECT * from calendar_event where meetupID=?", eventMapper, meetupId);
-  }
-
-  private RowMapper<CalendarEvent> eventMapper = (resultSet, ii) -> new CalendarEvent(
-      resultSet.getString("googleID"),
-      resultSet.getString("meetupID"));
-
-
+  void insertEvent(String googleId, String meetupId);
 }

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDao.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDao.java
@@ -11,19 +11,19 @@ import java.util.List;
 public class CalendarEventDao {
 
   @Autowired
-  JdbcTemplate template;
+  private JdbcTemplate template;
 
-  void insertRow(String googleId, String meetupId) {
+  void insertEvent(String googleId, String meetupId) {
     template.update(
         "INSERT INTO calendar_event VALUES (?, ?)", googleId, meetupId);
   }
 
-  List<CalendarEvent> getRowsByMeetupId(String meetupId) {
+  List<CalendarEvent> findEventsByMeetupId(String meetupId) {
     return template.query(
         "SELECT * from calendar_event where meetupID=?", eventMapper, meetupId);
   }
 
-  RowMapper<CalendarEvent> eventMapper = (resultSet, ii) -> new CalendarEvent(
+  private RowMapper<CalendarEvent> eventMapper = (resultSet, ii) -> new CalendarEvent(
       resultSet.getString("googleID"),
       resultSet.getString("meetupID"));
 

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDaoHsqlDbImpl.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDaoHsqlDbImpl.java
@@ -3,11 +3,11 @@ package com.chariotsolutions.meetupnotifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Component
+@Repository
 public class CalendarEventDaoHsqlDbImpl implements CalendarEventDao {
 
   @Autowired

--- a/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDaoHsqlDbImpl.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/CalendarEventDaoHsqlDbImpl.java
@@ -1,0 +1,31 @@
+package com.chariotsolutions.meetupnotifier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CalendarEventDaoHsqlDbImpl implements CalendarEventDao {
+
+  @Autowired
+  private JdbcTemplate template;
+
+  public void insertEvent(String googleId, String meetupId) {
+    template.update(
+        "INSERT INTO calendar_event VALUES (?, ?)", googleId, meetupId);
+  }
+
+  public List<CalendarEvent> findEventsByMeetupId(String meetupId) {
+    return template.query(
+        "SELECT * from calendar_event where meetupID=?", eventMapper, meetupId);
+  }
+
+  private RowMapper<CalendarEvent> eventMapper = (resultSet, ii) -> new CalendarEvent(
+      resultSet.getString("googleID"),
+      resultSet.getString("meetupID"));
+
+
+}

--- a/src/main/java/com/chariotsolutions/meetupnotifier/EventIdRow.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/EventIdRow.java
@@ -1,0 +1,20 @@
+package com.chariotsolutions.meetupnotifier;
+
+public class EventIdRow {
+  private String googleId;
+  private String meetupId;
+
+  public EventIdRow(String googleId, String meetupId) {
+    this.googleId = googleId;
+    this.meetupId = meetupId;
+  }
+
+  public String getGoogleId() {
+    return googleId;
+  }
+
+  public String getMeetupId() {
+    return meetupId;
+  }
+
+}

--- a/src/main/java/com/chariotsolutions/meetupnotifier/MeetupNotifierImpl.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/MeetupNotifierImpl.java
@@ -6,36 +6,52 @@ import com.google.api.services.calendar.model.Event;
 import com.chariotsolutions.meetupnotifier.meetup.api.GoogleConverter;
 import com.chariotsolutions.meetupnotifier.meetup.api.MeetupQuery;
 import com.chariotsolutions.meetupnotifier.meetup.api.MeetupQueryExecutor;
+import com.chariotsolutions.meetupnotifier.meetup.api.messages.Result;
 
-import com.chariotsolutions.meetupnotifier.meetup.api.messages.Results;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 
 @Component
 @EnableScheduling
 public class MeetupNotifierImpl {
 
   private static final Logger logger = LoggerFactory.getLogger(MeetupNotifierImpl.class);
+  @Autowired
+  DataSource ds;
 
   private String[] groups;
 
   public void queryAndNotify() throws IOException {
     for (String meetupGroupName : groups) {
-      Results results = new MeetupQueryExecutor().executeQuery(new MeetupQuery(meetupGroupName));
+      JdbcTemplate template = new JdbcTemplate(ds);
+      String metupInCalendarQuery = "SELECT count(*) from id_table where meetupID=?";
 
-      List<Event> events = results.getResults().stream()
+      List<Result> results = new MeetupQueryExecutor()
+          .executeQuery(new MeetupQuery(meetupGroupName)).getResults().stream()
+          .filter(t -> template.queryForObject(metupInCalendarQuery, Integer.class, t.getId()) == 0)
+          .collect(Collectors.toList());
+
+      List<Event> events = results.stream()
           .map(new GoogleConverter()::convertTo)
           .collect(Collectors.toList());
 
+      Iterator<Result> meetupIter = results.iterator();
+
       for (Event googleEvent : events) {
-        App.cal.events().insert("primary", googleEvent).execute();
+        Event insertedEvent = App.cal.events().insert("primary", googleEvent).execute();
+        template.update("INSERT INTO id_table VALUES (?, ?)",
+                        insertedEvent.getId(), meetupIter.next().getId());
         logger.debug("An event was added to the calendar successfully");
       }
     }

--- a/src/main/java/com/chariotsolutions/meetupnotifier/MeetupNotifierImpl.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/MeetupNotifierImpl.java
@@ -10,40 +10,33 @@ import com.chariotsolutions.meetupnotifier.meetup.api.messages.Result;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
-import javax.sql.DataSource;
 
 @Component
 @EnableScheduling
 public class MeetupNotifierImpl {
 
   @Autowired
-  DataSource ds;
+  CalendarEventDao dao;
 
   private String[] groups;
 
   public void queryAndNotify() throws IOException {
     for (String meetupGroupName : groups) {
-      JdbcTemplate template = new JdbcTemplate(ds);
-      String metupInCalendarQuery = "SELECT * from calendar_event where meetupID=?";
-
       List<Result> results = new MeetupQueryExecutor()
           .executeQuery(new MeetupQuery(meetupGroupName)).getResults();
 
       for (Result result : results) {
         Event gev = new GoogleConverter().convertTo(result);
-        List<CalendarEvent> tab = template.query(metupInCalendarQuery, eventMapper, result.getId());
+        List<CalendarEvent> tab = dao.getRowsByMeetupId(result.getId());
 
         if (tab.size() == 0) {
           Event insertedEvent = App.cal.events().insert("primary", gev).execute();
-          template.update("INSERT INTO calendar_event VALUES (?, ?)",
-              insertedEvent.getId(), result.getId());
+          dao.insertRow(insertedEvent.getId(), result.getId());
         } else {
           App.cal.events().update("primary", tab.get(0).getGoogleId(), gev).execute();
         }
@@ -51,9 +44,6 @@ public class MeetupNotifierImpl {
     }
   }
 
-  RowMapper<CalendarEvent> eventMapper = (resultSet, ii) -> new CalendarEvent(
-      resultSet.getString("googleID"),
-      resultSet.getString("meetupID"));
 
   @Value("${meetup.groups}")
   public void setGroups(String[] groups) {

--- a/src/main/java/com/chariotsolutions/meetupnotifier/MeetupNotifierImpl.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/MeetupNotifierImpl.java
@@ -32,11 +32,11 @@ public class MeetupNotifierImpl {
 
       for (Result result : results) {
         Event gev = new GoogleConverter().convertTo(result);
-        List<CalendarEvent> tab = dao.getRowsByMeetupId(result.getId());
+        List<CalendarEvent> tab = dao.findEventsByMeetupId(result.getId());
 
         if (tab.size() == 0) {
           Event insertedEvent = App.cal.events().insert("primary", gev).execute();
-          dao.insertRow(insertedEvent.getId(), result.getId());
+          dao.insertEvent(insertedEvent.getId(), result.getId());
         } else {
           App.cal.events().update("primary", tab.get(0).getGoogleId(), gev).execute();
         }

--- a/src/main/java/com/chariotsolutions/meetupnotifier/meetup/api/GoogleConverter.java
+++ b/src/main/java/com/chariotsolutions/meetupnotifier/meetup/api/GoogleConverter.java
@@ -27,7 +27,7 @@ public class GoogleConverter implements ResultConverter<Event> {
         location = "Location has been marked private, view the group on meetup.com for details.";
       } else {
         location = "The location for this meetup has not yet been set."
-                 + "View the group on meetup.com for updates.";
+                 + " View the group on meetup.com for updates.";
       }
     }
 

--- a/src/main/resources/context.xml
+++ b/src/main/resources/context.xml
@@ -3,12 +3,15 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:task="http://www.springframework.org/schema/task"
+       xmlns:jdbc="http://www.springframework.org/schema/jdbc"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context.xsd
         http://www.springframework.org/schema/task
-        http://www.springframework.org/schema/task/spring-task.xsd">
+        http://www.springframework.org/schema/task/spring-task.xsd
+        http://www.springframework.org/schema/jdbc
+        http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
   <context:component-scan base-package="com.chariotsolutions.meetupnotifier"/>
   <context:property-placeholder location="classpath:meetupGroups.properties"/>
@@ -18,5 +21,10 @@
                     fixed-rate="${checkschedule.fixed-rate}"
                     initial-delay="${checkschedule.initial-delay}"/>
   </task:scheduled-tasks>
+
+  <jdbc:embedded-database id="dataSource" type="HSQL"/>
+  <jdbc:initialize-database data-source="dataSource">
+    <jdbc:script location="classpath:schema.sql"/>
+  </jdbc:initialize-database>
 
 </beans>

--- a/src/main/resources/context.xml
+++ b/src/main/resources/context.xml
@@ -16,6 +16,7 @@
   <context:component-scan base-package="com.chariotsolutions.meetupnotifier"/>
   <context:property-placeholder location="classpath:meetupGroups.properties"/>
 
+
   <task:scheduled-tasks>
     <task:scheduled ref="meetupNotifierImpl" method="queryAndNotify"
                     fixed-rate="${checkschedule.fixed-rate}"
@@ -27,4 +28,7 @@
     <jdbc:script location="classpath:schema.sql"/>
   </jdbc:initialize-database>
 
+  <bean class="org.springframework.jdbc.core.JdbcTemplate" name="dataSourceTemplate">
+    <constructor-arg ref="dataSource"/>
+  </bean>
 </beans>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,7 @@
 log4j.rootLogger=DEBUG, A1
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-5p [%t]: %m%n
+log4j.appender.A1.layout.ConversionPattern=%-5p [%c{1}]: %m%n
+
+log4j.logger.org.apache.http.wire=WARN
+log4j.logger.org.apache.http.headers=WARN

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE id_table(
+  googleID VARCHAR(1024) NOT NULL, -- 1024 is the maximum length of a Google calendar event ID
+  meetupID VARCHAR(1024)   -- Not sure about this one :/
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE id_table(
+CREATE TABLE calendar_event(
   googleId VARCHAR(1024) NOT NULL, -- 1024 is the maximum length of a Google calendar event ID
   meetupId VARCHAR(1024) NOT NULL,
   UNIQUE (googleId, meetupId)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 CREATE TABLE id_table(
-  googleID VARCHAR(1024) NOT NULL, -- 1024 is the maximum length of a Google calendar event ID
-  meetupID VARCHAR(1024)   -- Not sure about this one :/
+  googleId VARCHAR(1024) NOT NULL, -- 1024 is the maximum length of a Google calendar event ID
+  meetupId VARCHAR(1024) NOT NULL,
+  UNIQUE (googleId, meetupId)
 );


### PR DESCRIPTION
Added an in-memory database that is used to track events that have been added to the calendar.
- New events since the last check are added to the calendar
- Preexisting events have their details updated to match with the meetup.com event, whether or not there has been a change

cc: issue #14 
